### PR TITLE
Improve text-view model/store testing

### DIFF
--- a/src/ineffable/src/features/text-view/document-model.test.ts
+++ b/src/ineffable/src/features/text-view/document-model.test.ts
@@ -1,31 +1,18 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { DocumentModel } from "./document-model";
-import { useDocStore } from "./document-store";
+import { createDocStore } from "./document-store";
 
 describe("DocumentModel", () => {
+  let store: ReturnType<typeof createDocStore>;
   let model: DocumentModel;
 
   beforeEach(() => {
-    // Reset the store before each test
-    const store = useDocStore.getState();
-    useDocStore.setState((state) => ({
-      ...state,
-      elements: {},
-      annotations: {},
-      elementAnnotations: [],
-      versions: {},
-      currentVersionNumber: null,
-      nextVersionNumber: 0,
-    }));
-    model = new DocumentModel();
-    // DEBUGGING: why is this logging 'null'? Is the setState running async?
-    console.log(
-      "DocumentModel initialized " + model._store.currentVersionNumber
-    );
+    store = createDocStore();
+    model = new DocumentModel(store);
   });
 
-  it.only("should initialize with empty store and create root element", () => {
-    expect(model._store.currentVersionNumber).not.toBeNull();
+  it("should initialize with empty store and create root element", () => {
+    expect(store.getState().currentVersionNumber).not.toBeNull();
     expect(model.getRootElement()).toBeDefined();
   });
 

--- a/src/ineffable/src/features/text-view/document-model.ts
+++ b/src/ineffable/src/features/text-view/document-model.ts
@@ -1,20 +1,22 @@
 import { Id, myNanoid } from "@/utils/nanoid";
-import { useDocStore } from "./document-store";
+import { useDocStore, type DocState } from "./document-store";
+import type { UseBoundStore } from "zustand";
 import { Annotation, Element, DocumentVersion, ElementKind } from "./types";
 import { getOrThrow } from "@/utils/maphelp";
 
 // --- DocumentModel: business logic, caching, parent relationships, immutable updates ---
 export class DocumentModel {
   // keep it public so we can access it in tests, but otherwise treat it as private.
-  _store = useDocStore.getState();
+  _store: UseBoundStore<DocState>;
   private parentMap = new Map<Id, Id>();
   // TODO: handle annotations
 
-  constructor() {
+  constructor(store: UseBoundStore<DocState> = useDocStore) {
+    this._store = store;
     // initial build
     this.rebuildCaches();
     // Ensure we have a current version and root element
-    if (this._store.currentVersionNumber == null) {
+    if (this._store.getState().currentVersionNumber == null) {
       console.log("Creating initial root element");
       const rootId = myNanoid();
       const rootElement: Element = {
@@ -24,18 +26,18 @@ export class DocumentModel {
         childrenIds: [],
         createdAt: new Date(),
       };
-      this._store.addElement(rootElement);
-      this._store.addVersion(rootId);
+      this._store.getState().addElement(rootElement);
+      this._store.getState().addVersion(rootId);
     }
   }
 
   private rebuildCaches() {
     // build parentMap via traversal from current root
     this.parentMap.clear();
-    const curVer = this._store.currentVersionNumber;
+    const curVer = this._store.getState().currentVersionNumber;
     if (curVer == null) return;
-    const rootId = this._store.versions[curVer].rootId;
-    const root = this._store.getElement(rootId);
+    const rootId = this._store.getState().versions[curVer].rootId;
+    const root = this._store.getState().getElement(rootId);
     if (!root) {
       return;
     }
@@ -46,7 +48,7 @@ export class DocumentModel {
 
   private walkAndMapParents(id: Id, parent: Id) {
     this.parentMap.set(id, parent);
-    const el = this._store.getElement(id);
+    const el = this._store.getState().getElement(id);
     if (!el) return;
     el.childrenIds.forEach((childId) => this.walkAndMapParents(childId, id));
   }
@@ -61,12 +63,12 @@ export class DocumentModel {
    * @returns the root element of the current document version.
    */
   getRootElement(): Element {
-    const curVer = this._store.currentVersionNumber;
+    const curVer = this._store.getState().currentVersionNumber;
     if (curVer == null) {
       throw new Error("No current version set");
     }
-    const rootId = this._store.versions[curVer].rootId;
-    const rootElement = this._store.getElement(rootId);
+    const rootId = this._store.getState().versions[curVer].rootId;
+    const rootElement = this._store.getState().getElement(rootId);
     if (!rootElement) {
       throw new Error(`Root element with id ${rootId} not found`);
     }
@@ -81,7 +83,7 @@ export class DocumentModel {
    * @returns
    */
   getElement(id: Id): Element {
-    const el = this._store.getElement(id);
+    const el = this._store.getState().getElement(id);
     if (!el) {
       throw new Error(`Element with id ${id} not found`);
     }
@@ -150,7 +152,7 @@ export class DocumentModel {
     if (origElement.kind === "document") {
       // Add a new version to the store, point at the new element.
       // (There must be exactly 1 — we checked above.)
-      this._store.addVersion(newElementIds[0]);
+      this._store.getState().addVersion(newElementIds[0]);
     } else {
       // bubble up the changes to the document level
       // TODO: handle annotations
@@ -173,7 +175,7 @@ export class DocumentModel {
 
       // At this point, newParent should be the new root document element
       // Add a new version with it as the root id.
-      this._store.addVersion(newParent.id);
+      this._store.getState().addVersion(newParent.id);
     }
   }
 
@@ -217,7 +219,7 @@ export class DocumentModel {
         childrenIds: childrenIds ?? [],
         createdAt: new Date(),
       };
-      this._store.addElement(element);
+      this._store.getState().addElement(element);
       return element.id;
     };
 
@@ -324,7 +326,7 @@ export class DocumentModel {
       createdAt: new Date(),
     };
     // Add the new parent to the store
-    this._store.addElement(newParent);
+    this._store.getState().addElement(newParent);
     // Update the parentMap for the new children
     newChildIds.forEach((cid) => {
       this.parentMap.set(cid, newParent.id);
@@ -386,7 +388,7 @@ export class DocumentModel {
   // }
 }
 
-export const docModel = new DocumentModel();
+export const docModel = new DocumentModel(useDocStore);
 
 // A wrapper hook for components to access element and be re-rendered when it changes.
 export function useElement(id: Id): Element {

--- a/src/ineffable/src/features/text-view/document-model.ts
+++ b/src/ineffable/src/features/text-view/document-model.ts
@@ -7,11 +7,11 @@ import { getOrThrow } from "@/utils/maphelp";
 // --- DocumentModel: business logic, caching, parent relationships, immutable updates ---
 export class DocumentModel {
   // keep it public so we can access it in tests, but otherwise treat it as private.
-  _store: UseBoundStore<DocState>;
+  _store: typeof useDocStore;
   private parentMap = new Map<Id, Id>();
   // TODO: handle annotations
 
-  constructor(store: UseBoundStore<DocState> = useDocStore) {
+  constructor(store: typeof useDocStore = useDocStore) {
     this._store = store;
     // initial build
     this.rebuildCaches();

--- a/src/ineffable/src/features/text-view/document-store.test.ts
+++ b/src/ineffable/src/features/text-view/document-store.test.ts
@@ -1,23 +1,13 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useDocStore } from "./document-store";
+import { createDocStore } from "./document-store";
 import { myNanoid } from "@/utils/nanoid";
 
 // helper to reset store state while keeping methods
-function resetStore() {
-  useDocStore.setState((state) => ({
-    ...state,
-    elements: {},
-    annotations: {},
-    elementAnnotations: [],
-    versions: {},
-    currentVersionNumber: null,
-    nextVersionNumber: 1,
-  }));
-}
+let store: ReturnType<typeof createDocStore>;
 
 describe("DocStore", () => {
   beforeEach(() => {
-    resetStore();
+    store = createDocStore();
   });
 
   it("adds single and multiple elements", () => {
@@ -25,37 +15,37 @@ describe("DocStore", () => {
     const id2 = myNanoid();
     const id3 = myNanoid();
 
-    const returnedId = useDocStore.getState().addElement({
+    const returnedId = store.getState().addElement({
       id: id1,
       kind: "word",
       contents: "hi",
       childrenIds: [],
     });
     expect(returnedId).toBe(id1);
-    const el1 = useDocStore.getState().elements[id1];
+    const el1 = store.getState().elements[id1];
     expect(el1).toBeDefined();
     expect(el1.createdAt).toBeInstanceOf(Date);
 
-    const ids = useDocStore.getState().addElements([
+    const ids = store.getState().addElements([
       { id: id2, kind: "word", contents: "a", childrenIds: [] },
       { id: id3, kind: "word", contents: "b", childrenIds: [] },
     ]);
     expect(ids).toEqual([id2, id3]);
-    expect(Object.keys(useDocStore.getState().elements)).toHaveLength(3);
+    expect(Object.keys(store.getState().elements)).toHaveLength(3);
   });
 
   it("creates annotations with mapping", () => {
     const elId = myNanoid();
-    useDocStore.getState().addElement({
+    store.getState().addElement({
       id: elId,
       kind: "word",
       contents: "x",
       childrenIds: [],
     });
-    useDocStore.setState((s) => ({ ...s, currentVersionNumber: 2 }));
+    store.setState((s) => ({ ...s, currentVersionNumber: 2 }));
 
     const annId = myNanoid();
-    const ret = useDocStore
+    const ret = store
       .getState()
       .addAnnotation(
         {
@@ -68,9 +58,9 @@ describe("DocStore", () => {
         elId
       );
     expect(ret).toBe(annId);
-    const ann = useDocStore.getState().annotations[annId];
+    const ann = store.getState().annotations[annId];
     expect(ann).toBeDefined();
-    const mapping = useDocStore
+    const mapping = store
       .getState()
       .elementAnnotations.find(
         (ea) => ea.annotationId === annId && ea.elementId === elId
@@ -82,10 +72,10 @@ describe("DocStore", () => {
   it("updates annotation validity", () => {
     const eId = myNanoid();
     const aId = myNanoid();
-    useDocStore
+    store
       .getState()
       .addElement({ id: eId, kind: "word", contents: "y", childrenIds: [] });
-    useDocStore
+    store
       .getState()
       .addAnnotation(
         {
@@ -97,8 +87,8 @@ describe("DocStore", () => {
         },
         eId
       );
-    useDocStore.getState().updateElementAnnotationValidity(eId, aId, 5);
-    const mapping = useDocStore
+    store.getState().updateElementAnnotationValidity(eId, aId, 5);
+    const mapping = store
       .getState()
       .elementAnnotations.find(
         (ea) => ea.annotationId === aId && ea.elementId === eId
@@ -108,25 +98,25 @@ describe("DocStore", () => {
 
   it("manages versions", () => {
     const rootId = myNanoid();
-    const ver = useDocStore.getState().addVersion(rootId);
+    const ver = store.getState().addVersion(rootId);
     expect(ver).toBe(1);
-    expect(useDocStore.getState().currentVersionNumber).toBe(1);
-    expect(useDocStore.getState().versions[1].rootId).toBe(rootId);
-    expect(useDocStore.getState().nextVersionNumber).toBe(2);
+    expect(store.getState().currentVersionNumber).toBe(1);
+    expect(store.getState().versions[1].rootId).toBe(rootId);
+    expect(store.getState().nextVersionNumber).toBe(2);
 
     // Add another version
     const newRootId = myNanoid();
-    const newVer = useDocStore.getState().addVersion(newRootId);
+    const newVer = store.getState().addVersion(newRootId);
     expect(newVer).toBe(2);
-    expect(useDocStore.getState().currentVersionNumber).toBe(2);
-    expect(useDocStore.getState().versions[2].rootId).toBe(newRootId);
-    expect(useDocStore.getState().nextVersionNumber).toBe(3);
+    expect(store.getState().currentVersionNumber).toBe(2);
+    expect(store.getState().versions[2].rootId).toBe(newRootId);
+    expect(store.getState().nextVersionNumber).toBe(3);
 
     // Switch back to first version
-    useDocStore.getState().switchCurrentVersion(1);
-    expect(useDocStore.getState().currentVersionNumber).toBe(1);
-    expect(useDocStore.getState().versions[1].rootId).toBe(rootId);
+    store.getState().switchCurrentVersion(1);
+    expect(store.getState().currentVersionNumber).toBe(1);
+    expect(store.getState().versions[1].rootId).toBe(rootId);
 
-    expect(() => useDocStore.getState().switchCurrentVersion(99)).toThrow();
+    expect(() => store.getState().switchCurrentVersion(99)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- refactor `document-store` to allow passing custom storage and export a factory
- update `DocumentModel` to accept a store instance and use `getState()`
- clean up and refactor store and model tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687814934a448331831d6314a98fd41c