### PR TITLE
Fix contents handling

### DIFF
--- a/src/ineffable/src/features/text-view/document-model.test.ts
+++ b/src/ineffable/src/features/text-view/document-model.test.ts
@@ -29,6 +29,7 @@ describe("DocumentModel", () => {
     expect(ids).toHaveLength(1);
     const sentence = model.getElement(ids[0]);
     expect(sentence.kind).toBe("sentence");
+    expect(sentence.contents).toBe("");
     expect(sentence.childrenIds).toHaveLength(2);
     const first = model.getElement(sentence.childrenIds[0]);
     const second = model.getElement(sentence.childrenIds[1]);
@@ -47,9 +48,12 @@ describe("DocumentModel", () => {
     expect(ids).toHaveLength(1);
     const doc = model.getElement(ids[0]);
     expect(doc.kind).toBe("document");
+    expect(doc.contents).toBe("");
     expect(doc.childrenIds.length).toBe(2);
     const para1 = model.getElement(doc.childrenIds[0]);
     const para2 = model.getElement(doc.childrenIds[1]);
+    expect(para1.contents).toBe("");
+    expect(para2.contents).toBe("");
     expect(para1.childrenIds.length).toBe(1);
     expect(para2.childrenIds.length).toBe(2);
   });
@@ -69,11 +73,15 @@ describe("DocumentModel", () => {
     expect(updatedRoot.childrenIds.length).toBe(2);
     const para1 = model.getElement(updatedRoot.childrenIds[0]);
     const para2 = model.getElement(updatedRoot.childrenIds[1]);
+    expect(updatedRoot.contents).toBe("");
+    expect(para1.contents).toBe("");
+    expect(para2.contents).toBe("");
     expect(para1.kind).toBe("paragraph");
     expect(para1.childrenIds.length).toBe(1);
     expect(para2.kind).toBe("paragraph");
     expect(para2.childrenIds.length).toBe(2);
     const sentence1 = model.getElement(para1.childrenIds[0]);
+    expect(sentence1.contents).toBe("");
     expect(sentence1.kind).toBe("sentence");
     expect(sentence1.childrenIds.length).toBe(2);
     const word1 = model.getElement(sentence1.childrenIds[0]);
@@ -84,6 +92,7 @@ describe("DocumentModel", () => {
     expect(word2.contents).toBe("B.");
 
     const sentence2 = model.getElement(para2.childrenIds[0]);
+    expect(sentence2.contents).toBe("");
     expect(sentence2.kind).toBe("sentence");
     expect(sentence2.childrenIds.length).toBe(2);
     const word3 = model.getElement(sentence2.childrenIds[0]);
@@ -94,6 +103,7 @@ describe("DocumentModel", () => {
     expect(word4.contents).toBe("D.");
 
     const sentence3 = model.getElement(para2.childrenIds[1]);
+    expect(sentence3.contents).toBe("");
     expect(sentence3.kind).toBe("sentence");
     expect(sentence3.childrenIds.length).toBe(2);
     const word5 = model.getElement(sentence3.childrenIds[0]);
@@ -233,5 +243,18 @@ describe("DocumentModel", () => {
     expect(updatedParaXY.childrenIds.length).toBe(1);
     const updatedParaZW = model.getElement(updatedRoot.childrenIds[2]);
     expect(updatedParaZW.childrenIds.length).toBe(1);
+  });
+
+  it("computes full contents for non-leaf elements", () => {
+    const text = "A B.\n\nC D. E F.";
+    model.updateElement(model.getRootElement().id, text);
+
+    const root = model.getRootElement();
+    expect(model.computeFullContents(root.id)).toBe(text);
+
+    const para2 = model.getElement(root.childrenIds[1]);
+    const sentEF = model.getElement(para2.childrenIds[1]);
+    expect(model.computeFullContents(para2.id)).toBe("C D. E F.");
+    expect(model.computeFullContents(sentEF.id)).toBe("E F.");
   });
 });

--- a/src/ineffable/src/features/text-view/document-model.ts
+++ b/src/ineffable/src/features/text-view/document-model.ts
@@ -257,13 +257,13 @@ export class DocumentModel {
       kind: ElementKind,
       childrenIds: Id[] | undefined = undefined
     ): Id => {
-      if (text.trim() === "") {
+      if (kind === "word" && text.trim() === "") {
         throw new Error("Cannot create a word element with empty contents");
       }
       const element = {
         id: myNanoid(),
         kind,
-        contents: text,
+        contents: kind === "word" ? text : "",
         childrenIds: childrenIds ?? [],
         createdAt: new Date(),
       };
@@ -413,6 +413,19 @@ export class DocumentModel {
     // Replace with empty list to remove it from the parent's childrenIds.
     // This will bubble up to the root element, creating a new version.
     this._replaceElement(el, []);
+  }
+
+  computeFullContents(id: Id): string {
+    const el = this.getElement(id);
+    if (el.kind === "word") {
+      return el.contents ?? "";
+    }
+    const childTexts = el.childrenIds.map((cid) => this.computeFullContents(cid));
+    if (el.kind === "document") {
+      return childTexts.join("\n\n");
+    }
+    // sentence or paragraph
+    return childTexts.join(" ");
   }
 
   // // write paths incrementally update caches + store

--- a/src/ineffable/src/features/text-view/document-panel.tsx
+++ b/src/ineffable/src/features/text-view/document-panel.tsx
@@ -130,7 +130,7 @@ const DocumentPanel: React.FC<TextPanelProps> = ({ sliderValue, onSelect, select
         <textarea
           ref={textareaRef}
           autoFocus
-          defaultValue={el.contents}
+          defaultValue={docModel.computeFullContents(id)}
           onInput={(e) => {
             // Auto-expand height
             e.currentTarget.style.height = 'auto';

--- a/src/ineffable/src/features/text-view/document-store.test.ts
+++ b/src/ineffable/src/features/text-view/document-store.test.ts
@@ -47,6 +47,30 @@ describe("DocStore", () => {
     expect(Object.keys(store.getState().elements)).toHaveLength(3);
   });
 
+  it("throws when adding non-word element with contents", () => {
+    expect(() =>
+      store.getState().addElement({
+        id: myNanoid(),
+        kind: "sentence",
+        contents: "nope",
+        childrenIds: [],
+        createdAt: new Date(),
+      })
+    ).toThrow();
+
+    expect(() =>
+      store.getState().addElements([
+        {
+          id: myNanoid(),
+          kind: "paragraph",
+          contents: "bad",
+          childrenIds: [],
+          createdAt: new Date(),
+        },
+      ])
+    ).toThrow();
+  });
+
   it("creates annotations with mapping", () => {
     const elId = myNanoid();
     store.getState().addElement({

--- a/src/ineffable/src/features/text-view/document-store.ts
+++ b/src/ineffable/src/features/text-view/document-store.ts
@@ -100,6 +100,11 @@ const createState: StateCreator<
 
   // mutators
   addElement: (el: Element) => {
+    if (el.kind !== "word" && el.contents && el.contents !== "") {
+      throw new Error(
+        `Non-word element ${el.id} with kind ${el.kind} cannot have contents`
+      );
+    }
     set((state) => {
       state.elements[el.id] = el;
     });
@@ -110,6 +115,11 @@ const createState: StateCreator<
     const ids: Id[] = [];
     set((state) => {
       els.forEach((el) => {
+        if (el.kind !== "word" && el.contents && el.contents !== "") {
+          throw new Error(
+            `Non-word element ${el.id} with kind ${el.kind} cannot have contents`
+          );
+        }
         state.elements[el.id] = el;
         ids.push(el.id);
       });


### PR DESCRIPTION
## Summary
- throw when non-word elements are added with contents
- clear contents for non-word elements when parsing
- compute full element contents recursively
- use helper in document panel
- test contents rules and helper

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68787fbd15088331a304d65c4d6338e3