### PR TITLE
Improve text element interactions

### DIFF
--- a/src/ineffable/docs/todo.md
+++ b/src/ineffable/docs/todo.md
@@ -17,23 +17,24 @@ next: cleaning up state
 + get rid of contents in non-leaf elements and recompute dynamically, or ensure it updates with edits.
    + perhaps those are equivalent — I suppose I could have a lazy recompute or eager one. And really no need to store it. Let's make it dynamic, and add a cache if it seems warranted later.
 + fix storage so it actually persists (don't overwrite with sample text every time)
++ reuse unchanged child elements when editing mid-tree nodes
++ Further edits
+    + add a word
+    + change a sentence
+        + change a couple of words
+        + split into two or more sentences
+    + add a sentence
+    + change a paragraph — should "just work" based on sentences if I do it right
+    + remove a word
+    + delete a sentence
+    + add a paragraph
++ select vs edit gestures -- click to select, double-click or hit enter to edit?
+- merge!
+- add back annotations support
+- add time travel slider -- keep things read-only at first
 - check that changing word only rerenders its ancestors, not entire doc
    - fix as needed based on https://chatgpt.com/c/68542486-c028-8011-9044-2fc769faf28d?model=o4-mini — React.memo / PureComponent
-- reuse unchanged child elements when editing mid-tree nodes
-- Further edits
-    + add a word
-    - remove a word
-    - change a sentence
-        - change a couple of words
-        - split into two or more sentences
-    + add a sentence
-    - delete a sentence
-    - change a paragraph — should "just work" based on sentences if I do it right
-    - add a paragraph
-- add time travel slider -- keep things read-only at first
-- select vs edit gestures -- click to select, double-click or hit enter to edit?
 
-- add back annotations support
 
 - and then we can finally get to the best practices side of the house and then the first AI bits
 
@@ -42,4 +43,5 @@ idea (for later): add placeholder elements to the tree, or perhaps treat it as a
 
 future: 
 - real DB
+- periodic sync to google docs or file or something
 - 

--- a/src/ineffable/src/features/text-view/document-model.test.ts
+++ b/src/ineffable/src/features/text-view/document-model.test.ts
@@ -352,6 +352,39 @@ describe("DocumentModel", () => {
     expect(updatedWordX.contents).toBe("X.");
   });
 
+  it("deletes a word", () => {
+    model.updateElement(model.getRootElement().id, "A B.");
+    const root = model.getRootElement();
+    const para = model.getElement(root.childrenIds[0]);
+    const sent = model.getElement(para.childrenIds[0]);
+    const wordA = model.getElement(sent.childrenIds[0]);
+
+    model.deleteElement(wordA.id);
+
+    const updatedRoot = model.getRootElement();
+    const updatedPara = model.getElement(updatedRoot.childrenIds[0]);
+    const updatedSent = model.getElement(updatedPara.childrenIds[0]);
+    expect(updatedSent.childrenIds.length).toBe(1);
+    const remaining = model.getElement(updatedSent.childrenIds[0]);
+    expect(remaining.contents).toBe("B.");
+  });
+
+  it("deletes a sentence", () => {
+    model.updateElement(model.getRootElement().id, "A B. C D.");
+    const root = model.getRootElement();
+    const para = model.getElement(root.childrenIds[0]);
+    const firstSentence = model.getElement(para.childrenIds[0]);
+    const secondSentence = model.getElement(para.childrenIds[1]);
+
+    model.deleteElement(firstSentence.id);
+
+    const updatedRoot = model.getRootElement();
+    const updatedPara = model.getElement(updatedRoot.childrenIds[0]);
+    expect(updatedPara.childrenIds.length).toBe(1);
+    const remaining = model.getElement(updatedPara.childrenIds[0]);
+    expect(remaining.id).toEqual(secondSentence.id);
+  });
+
   describe("examples from docs", () => {
     it("1. 'E' -> 'F'", () => {
       const root = model.getRootElement();

--- a/src/ineffable/src/features/text-view/document-model.test.ts
+++ b/src/ineffable/src/features/text-view/document-model.test.ts
@@ -385,7 +385,73 @@ describe("DocumentModel", () => {
     expect(remaining.id).toEqual(secondSentence.id);
   });
 
-  describe("examples from docs", () => {
+  it("add a paragraph", () => {
+    model.updateElement(model.getRootElement().id, "A B.\n\nC D.");
+    const root = model.getRootElement();
+    const firstPara = model.getElement(root.childrenIds[0]);
+    const secondPara = model.getElement(root.childrenIds[1]);
+
+    model.addAfter(firstPara.id, "X Y. Z W.");
+
+    const updatedRoot = model.getRootElement();
+    expect(updatedRoot.childrenIds.length).toBe(3);
+    const newFirstPara = model.getElement(updatedRoot.childrenIds[0]);
+    const addedPara = model.getElement(updatedRoot.childrenIds[1]);
+    const newLastPara = model.getElement(updatedRoot.childrenIds[2]);
+    expect(model.computeFullContents(addedPara.id)).toBe("X Y. Z W.");
+    expect(newFirstPara.id).toEqual(firstPara.id);
+    expect(newLastPara.id).toEqual(secondPara.id);
+  });
+
+  it("delete last remaining word in a sentence", () => {
+    model.updateElement(model.getRootElement().id, "A B. D.");
+    const root = model.getRootElement();
+    const para = model.getElement(root.childrenIds[0]);
+    const firstSentence = model.getElement(para.childrenIds[0]);
+    const secondSentence = model.getElement(para.childrenIds[1]);
+    const wordD = model.getElement(secondSentence.childrenIds[0]);
+    // delete the only word in the second sentence
+    model.deleteElement(wordD.id);
+    // now we expect the second paragraph to also be gone
+    const updatedRoot = model.getRootElement();
+    const updatedPara = model.getElement(updatedRoot.childrenIds[0]);
+    // should only have one sentence left
+    expect(updatedPara.childrenIds.length).toBe(1);
+    const updatedSent = model.getElement(updatedPara.childrenIds[0]);
+    // and it should be the first sentence
+    expect(updatedSent.id).toEqual(firstSentence.id);
+  });
+
+  it("delete last remaining word in a one-sentence paragraph", () => {
+    model.updateElement(model.getRootElement().id, "D.");
+    const root = model.getRootElement();
+    const para = model.getElement(root.childrenIds[0]);
+    const firstSentence = model.getElement(para.childrenIds[0]);
+    const wordD = model.getElement(firstSentence.childrenIds[0]);
+    // delete the only word in the paragraph
+    model.deleteElement(wordD.id);
+    // now we expect the paragraph to also be gone
+    const updatedRoot = model.getRootElement();
+    expect(updatedRoot.childrenIds.length).toBe(0);
+  });
+
+  it("delete last remaining sentence in a paragraph", () => {
+    model.updateElement(model.getRootElement().id, "C D.\n\nE F.");
+    const root = model.getRootElement();
+    const para1 = model.getElement(root.childrenIds[0]);
+    const para2 = model.getElement(root.childrenIds[1]);
+    const onlySentence = model.getElement(para1.childrenIds[0]);
+    // delete the only sentence
+    model.deleteElement(onlySentence.id);
+    // now we expect the paragraph to be gone
+    const updatedRoot = model.getRootElement();
+    expect(updatedRoot.childrenIds.length).toBe(1);
+    const updatedPara = model.getElement(updatedRoot.childrenIds[0]);
+    // and it should be the first paragraph
+    expect(updatedPara.id).toEqual(para2.id);
+  });
+
+  describe("reuse elements correctly", () => {
     it("1. 'E' -> 'F'", () => {
       const root = model.getRootElement();
       model.updateElement(root.id, "E");


### PR DESCRIPTION
## Summary
- refactor DocumentPanel selection/edit workflow
- support keyboard delete and enter keys
- add tests for `DocumentModel.deleteElement`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879702527d48331bb1da9ee93c7d1dd